### PR TITLE
Fix wrong position of box around pin 1 for SIP

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -225,6 +225,9 @@ class Footgen():
         self.silkbox(silkx,silky)
         if self.mirror:
             silkx *= -1
+        if self.width == 0:
+            silkx *= 0.5
+            silky *= 0.5
         self.box_corners(-silkx,-silky,-silkx+self.pitch,-silky+self.pitch)
 
     def dih(self):


### PR DESCRIPTION
Please consider merging this change that fixes the position for the box around pin 1 of SIP footprints.
Without this change the box is positioned on the corner of the corresponding DIP footprint which is twice as large and tall.
