### PR TITLE
incorrect pad size was using default class size.

### DIFF
--- a/footgen/geda.py
+++ b/footgen/geda.py
@@ -90,6 +90,8 @@ class Generator(BaseGenerator):
 
         flag_list = []
         if "circle" in self.options_list:
+            self.width = self.diameter
+            self.height = self.diameter
             pass
         elif "round" in self.options_list:
             pass


### PR DESCRIPTION
I am seeing some odd stuff in the samples when using gEDA Not sure how many issues exist but initially i noted all pads generated by the BGA example are default in size. Looking at the code in kicad.py it seems a case is made for add_pad if its a "circle" to set width and height to diameter.